### PR TITLE
categoria e descricao esta na mesma linha ao listar

### DIFF
--- a/tarefas.c
+++ b/tarefas.c
@@ -6,14 +6,17 @@ ERROS criar(Tarefa tarefas[], int *pos){
     if(*pos >= TOTAL)
         return MAX_TAREFA;
 
-    printf("Entre com a prioridade: ");
+       printf("Entre com a prioridade: ");
     scanf("%d", &tarefas[*pos].prioridade);
     clearBuffer();
+
     printf("Entre com a categoria: ");
-    fgets(tarefas[*pos].categoria, 100, stdin);
+    fgets(tarefas[*pos].categoria, sizeof(tarefas[*pos].categoria), stdin);
+    tarefas[*pos].categoria[strcspn(tarefas[*pos].categoria, "\n")] = '\0'; // Remove a quebra de linha
 
     printf("Entre com a descricao: ");
-    fgets(tarefas[*pos].descricao, 300, stdin);
+    fgets(tarefas[*pos].descricao, sizeof(tarefas[*pos].descricao), stdin);
+    tarefas[*pos].descricao[strcspn(tarefas[*pos].descricao, "\n")] = '\0'; // Remove a quebra de linha
 
     *pos = *pos + 1;
 


### PR DESCRIPTION
Ao utilizar a função listar a categoria e descrição sofriam uma quebra de linha, agora com as modificações eles permanecem na mesma linha.